### PR TITLE
Bugfix OLED rotation picker not correctly initialised

### DIFF
--- a/PMD/FormPMD.cs
+++ b/PMD/FormPMD.cs
@@ -131,7 +131,6 @@ namespace PMD {
             comboBoxDisplaySpeed.Items.Add("1.0s");
             comboBoxDisplaySpeed.Items.Add("1.2s");
             comboBoxDisplaySpeed.Items.Add("1.4s");
-            comboBoxDisplaySpeed.Items.Add("1.4s");
 
             comboBoxAveraging.Items.Add("29µs (1 sample)");
             comboBoxAveraging.Items.Add("1.87ms (64 samples)");

--- a/PMD/FormPMD.cs
+++ b/PMD/FormPMD.cs
@@ -121,7 +121,7 @@ namespace PMD {
 
             comboBoxOledRotation.Items.Add("0 deg");
             comboBoxOledRotation.Items.Add("180 deg");
-            comboBoxTimeoutAction.SelectedIndex = 0;
+            comboBoxOledRotation.SelectedIndex = 0;
 
             comboBoxDisplaySpeed.Items.Add("0.0s");
             comboBoxDisplaySpeed.Items.Add("0.2s");


### PR DESCRIPTION
The comboBoxOledRotation was not having it's .SelectedIndex set, and the comboBoxTimeoutAction was accidentally set twice.