### PR TITLE
Bugfix remove redundant DisplaySpeed 1.4s option

### DIFF
--- a/PMD/FormPMD.cs
+++ b/PMD/FormPMD.cs
@@ -131,7 +131,6 @@ namespace PMD {
             comboBoxDisplaySpeed.Items.Add("1.0s");
             comboBoxDisplaySpeed.Items.Add("1.2s");
             comboBoxDisplaySpeed.Items.Add("1.4s");
-            comboBoxDisplaySpeed.Items.Add("1.4s");
 
             comboBoxAveraging.Items.Add("29µs (1 sample)");
             comboBoxAveraging.Items.Add("1.87ms (64 samples)");


### PR DESCRIPTION
"1.4s" option in the combo box was added twice.